### PR TITLE
Be more forgiving with available CPU scaling governors assert

### DIFF
--- a/adb/contrib/high.py
+++ b/adb/contrib/high.py
@@ -146,7 +146,7 @@ def _InitCache(device):
         '/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors')
     if out:
       available_governors = sorted(i for i in out.split())
-      assert set(available_governors).issubset(
+      assert set(available_governors).intersect(
           KNOWN_CPU_SCALING_GOVERNOR_VALUES), available_governors
 
     available_frequencies = device.PullContent(


### PR DESCRIPTION
Rather than enforcing that all of the device's scaling governors are
in the KNOWN_CPU_SCALING_GOVERNOR_VALUES list, enforce that at least
one of them is in the list. We already enforce that the desired governor
is in the known list when we try to set it, so we just need to ensure
that there's at least one available which is valid.
