### PR TITLE
Plumb timeout through ReadAndDispatch, Shell(), use in long-running cmds

### DIFF
--- a/adb/common.py
+++ b/adb/common.py
@@ -63,7 +63,7 @@ class Handle(object):
     self._timeout_ms = timeout_ms or DEFAULT_TIMEOUT_MS
 
   def Timeout(self, timeout_ms):
-    return timeout_ms if timeout_ms is not None else self._timeout_ms
+    return max(timeout_ms, self._timeout_ms)
 
   # TODO(bpastene) Remove all dependencies on a non UsbHandle needing port_path
   @property


### PR DESCRIPTION
This fixes a bug in which ReadAndDispatch hits a timeout for a
long-running command (eg. 'pm list packages') and assumes that the
connection was broken. When the command finally finishes, we get errors
when reading output from subsequent commands.
